### PR TITLE
Add lightning address to addition template

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ We also support [BOLT12](https://bolt12.org/) (`bolt12_single` and `bolt12_recur
   "lightning": true,
   "bolt12_single": "BOLT12 for a single offer",
   "bolt12_recurring": "BOLT12 for a recurring offer",
+  "lnaddr": "Lightning address",
   "tags": [
     "Bitcoin",
     "Lightning"


### PR DESCRIPTION
Just adding the lightning address option to the addition JSON template in the README.