### PR TITLE
change: point to projects page

### DIFF
--- a/donatees/0xb10c.json
+++ b/donatees/0xb10c.json
@@ -2,7 +2,7 @@
   "name": "0xB10C",
   "github": "0xB10C",
   "twitter": "0xB10C",
-  "donate": "https://pay.b10c.me/apps/2oK2hM8h4TEwierrgZoPECwLYs6p/pos",
+  "donate": "https://b10c.me/projects",
   "avatar": "https://b10c.me/0xb10c.png",
   "description": "Bitcoin Engineer and Researcher. Projects: [b10c.me/projects](https://b10c.me/projects). Occasionally contribute to Bitcoin Core, e.g. [#22006](https://github.com/bitcoin/bitcoin/pull/22006), too.",
   "lightning": true,


### PR DESCRIPTION
The old btcpayserver store broke while updating to a newer version, pointing to my own site I can more easily change when this happens.