### PR TITLE
Sjors: update bolt12, add recurring, add Nostr

### DIFF
--- a/donatees/sjors-provoost.json
+++ b/donatees/sjors-provoost.json
@@ -2,11 +2,13 @@
   "name": "Sjors Provoost",
   "github": "Sjors",
   "twitter": "provoost",
-  "mastodon": "https://m.sprovoost.nl/@sjors",
+  "nostr": "npub1s6z7hmmx2vud66f3utxd70qem8cwtggx0jgc7gh8pqwz2k8cltuqrdwk4c",
   "donate": "https://github.com/sponsors/Sjors",
   "avatar": "https://mastodon.sprovoost.nl/system/accounts/avatars/109/887/537/079/015/035/original/e6c45ff623707857.png",
   "description": "I've been contributing to Bitcoin Core on a part-time basis since mid 2017. Most of my time is spent on reviewing and testing work by others, but I also created my own pull requests. Bitcoin ACKs provides a nice overview of my activity on the repo.",
   "tags": ["Bitcoin Core"],
-  "bolt12_single": "lno1pg4y7ur9dcs8xmm4wf3k2gryv4mx2mr0wpkk2mn5ypjx7mnpw35k7m3qvehhygzndfhhyuc5pefk5mmjwvs9qun0wehk7um5rcsrwlufzdn408gvmlpgxw7rywsaq9g5a6jq6jxvapknrcucyglqevlsgqgf4k7rc5runmkuex8ue6jrj0r9jszltusclp4yd0z4mekwa7k8dfskd2ltdlfmcdnm6f0sv5jsrs6t3vkql8nav0vl6w4l44gmaf4c",
+  "lightning": true,
+  "bolt12_single": "lno1pgs57ur9dcs9xmm4wf3k2grrdah8gunfvf6hg6t0dcsxgmmwv96xjmmwzg89x6n0wfejq5rjdamx7mmnwstzzqeh07y3xe6hn5xdls5r80pj8gwsz52wafqdfrxwsmf3uwvzy0svkv",
+  "bolt12_recurring": "lno1pg557ur9dcs9xmm4wf3k2grrdah8gunfvf6hg6t0dcsx6mmww35xc7fqv3hkuct5d9hkuysw2d4x7unnypg8ymmkdahhxaqkyypnwlufzdn408gvmlpgxw7rywsaq9g5a6jq6jxvapknrcucyglqevc6qgpqz",
   "lnaddr": "sjors@sprovoost.nl"
 }


### PR DESCRIPTION
Turns out I'm so OG that my bolt12 is invalid nowadays: https://github.com/ElementsProject/lightning/issues/7402

Generated a new one. Also added a recurring version, set to monthly.

I deleted my Mastodon instance a while ago and joined the cool kids on Nostr.

The commit is PGP signed.